### PR TITLE
update: dependencies

### DIFF
--- a/template/app/build.gradle
+++ b/template/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
 
     // Android
-    implementation 'androidx.core:core-ktx:1.9.0-alpha01'
+    implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'

--- a/template/app/build.gradle
+++ b/template/app/build.gradle
@@ -57,22 +57,22 @@ android {
 dependencies {
     //Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
 
     // Android
-    implementation 'androidx.core:core-ktx:1.7.0-beta02'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.core:core-ktx:1.9.0-alpha01'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
+    implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
 
     // Preferences
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'com.github.tfcporciuncula:flow-preferences:1.3.2'
 
     // Material Design
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     // UI
     implementation "dev.chrisbanes.insetter:insetter:0.6.0"

--- a/template/build.gradle
+++ b/template/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/gradle/wrapper/gradle-wrapper.properties
+++ b/template/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
Update the following dependencies:

- com.google.android.material from 1.4.0 to 1.5.0
- androidx.preference:preference-ktx from 1.1.1 to 1.2.0
- androidx.lifecycle:lifecycle-runtime-ktx from 2.3.1 to 2.4.1
- androidx.lifecycle:lifecycle-viewmodel-ktx from 2.3.1 to 2.4.1
- androidx.preference:preference-ktx from 1.1.1 to 1.2.0
- androidx.coordinatorlayout:coordinatorlayout from 1.1.0 to 1.2.0
- androidx.appcompat:appcompat from 1.3.1 to 1.4.1
- androidx.core:core-ktx from 1.7.0-beta02 to 1.7.0
- org.jetbrains.kotlinx:kotlinx-coroutines-core from 1.5.1 to 1.5.2
- com.android.tools.build:gradle from 7.0.2 to 7.1.2
