### PR TITLE
updated: libraries and dependencies

### DIFF
--- a/template/androidApp/src/main/java/io/bloco/template/features/list/ListScreen.kt
+++ b/template/androidApp/src/main/java/io/bloco/template/features/list/ListScreen.kt
@@ -53,6 +53,7 @@ fun ListScreen(
 }
 
 @Composable
+@Suppress("DEPRECATION") // SwipeRefresh migration not available in material 3 just for 2
 private fun ListBooks(
     state: ListScreenUiState,
     onRefresh: () -> Unit,

--- a/template/gradle/libs.versions.toml
+++ b/template/gradle/libs.versions.toml
@@ -6,24 +6,24 @@ sdk-min = "23"
 gradle-android = "7.3.1"
 gradle-versions = "0.43.0"
 
-compose = "1.3.0"
-compose-material = "1.0.0"
+compose = "1.3.2"
+compose-material = "1.0.1"
 compose-compiler = "1.3.2"
 compose-navigation = "2.5.3"
 compose-navigation-hilt = "1.0.0"
-accompanist = "0.27.0"
+accompanist = "0.28.0"
 datastore = "1.0.0"
 
 lint = "30.3.1"
-detekt = "1.21.0"
+detekt = "1.22.0"
 
 javax = "1"
-hilt = "2.44"
-mockk = "1.13.2"
+hilt = "2.44.2"
+mockk = "1.13.3"
 hilt-testing = "2.44"
 dagger = "2.43.2"
 kotlin = "1.7.20"
-ktor = "2.1.3"
+ktor = "2.2.1"
 jvm = "5.4.1"
 coroutines = "1.6.4"
 
@@ -61,9 +61,9 @@ compose-tools-debug = { group = "androidx.compose.ui", name = "ui-tooling", vers
 compose-tools-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose" }
 
 # Testing
-test-core = { group = "androidx.test", name = "core", version = "1.5.0-rc01" }
-test-junit = { group = "androidx.test.ext", name = "junit", version = "1.1.3" }
-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version = "3.4.0" }
+test-core = { group = "androidx.test", name = "core", version = "1.5.0" }
+test-junit = { group = "androidx.test.ext", name = "junit", version = "1.1.4" }
+test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version = "3.5.0" }
 test-compose = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose" }
 test-navigation = { group = "androidx.navigation", name = "navigation-testing", version.ref = "compose-navigation" }
 


### PR DESCRIPTION
Kotlin left in this version because of the [Compose Compiler](https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility).
Swipe is not ready for Material 3